### PR TITLE
Skip file if you get an error while editing

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -424,7 +424,7 @@ function handleSubject (subject, auth) {
             var summary = 'Maintenance: [[mw:RL/MGU]] / [[mw:RL/JD]] - ' + summaries.join(', ');
             printSaving(subject, summary);
             client.edit(page, newContent, summary, function (err) {
-              err ? reject(err) : resolve(); // promisify
+              err ? reject(new SkipFileError(err.message)) : resolve(); // promisify
             });
           });
         }).catch(reject);


### PR DESCRIPTION
Instead of terminating entirely. E.g. if you get abusefilter-warning